### PR TITLE
VZ-8245: Fix warning indicating XA transaction is not enabled in Keycloak 20.0.1

### DIFF
--- a/quarkus/container/Dockerfile_verrazzano
+++ b/quarkus/container/Dockerfile_verrazzano
@@ -18,17 +18,29 @@ RUN (cd /tmp/keycloak && \
 
 RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
 
+# Define Quarkus configugration to enable transaction recovery
+RUN echo "quarkus.transaction-manager.enable-recovery=true" >> /opt/keycloak/conf/quarkus.properties
+
 RUN chmod -R g+rwX /opt/keycloak
+
+# Create a base directory for ObjectStore, required for transaction recovery
+RUN (mkdir /opt/xa && \
+    chmod -R g+rwX /opt/xa)
 
 FROM ghcr.io/oracle/oraclelinux:8-slim
 ENV LANG en_US.UTF-8
 
 COPY --from=build_env --chown=1000:0 /opt/keycloak /opt/keycloak
+COPY --from=build_env --chown=1000:0 /opt/xa /opt/xa
 
 RUN microdnf update -y && \
     microdnf install -y --nodocs java-11-openjdk-headless glibc-langpack-en && microdnf clean all && rm -rf /var/cache/yum/* && \
     echo "keycloak:x:0:root" >> /etc/group && \
     echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
+
+# Narayana JTA creates ObjectStore under the directory derived from system property user.dir, so make /opt/xa as working directory
+# where userid 1000 can create files
+WORKDIR /opt/xa
 
 COPY THIRD_PARTY_LICENSES.txt LICENSE.txt README.md SECURITY.md /licenses/
 


### PR DESCRIPTION
This PR fixes the warning in Keycloak 20.0.1 pod for XA transaction recovery, by defining a property quarkus.transaction-manager.enable-recovery=true in /opt/keycloak/conf/quarkus.properties

The Narayana JTA attempts to create <user.dir>/ObjectStore when XA recovery is enabled, defined WORKDIR where the user id 1000 can write.