### PR TITLE
VZ-8810: Update kafka-clients to v3.4.0

### DIFF
--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/base/org/apache/kafka/client/main/module.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/base/org/apache/kafka/client/main/module.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2020, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module name="org.apache.kafka.client" xmlns="urn:jboss:module:1.8">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="org.apache.kafka:kafka-clients:3.4.0"></artifact>
+    </resources>
+
+    <dependencies>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+        <module name="java.management"/>
+        <module name="java.security.jgss"/>
+        <module name="java.security.sasl"/>
+        <module name="org.slf4j"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
This change updates kafka-clients to v3.4.0 in Keycloak 15.0.2