### PR TITLE
VZ-8226: Use Agroal v1.15 in Keycloak to resolve acquisition timeout while waiting for new connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 
         <!-- Databases -->
         <mysql.version>8.0.23</mysql.version>
-        <mysql.driver.version>8.0.30</mysql.driver.version>
+        <mysql.driver.version>8.0.28</mysql.driver.version>
         <postgresql.version>13.2</postgresql.version>
         <postgresql.driver.version>42.3.3</postgresql.driver.version>
         <mariadb.version>10.3.27</mariadb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 
         <!-- Databases -->
         <mysql.version>8.0.23</mysql.version>
-        <mysql.driver.version>8.0.28</mysql.driver.version>
+        <mysql.driver.version>8.0.30</mysql.driver.version>
         <postgresql.version>13.2</postgresql.version>
         <postgresql.driver.version>42.3.3</postgresql.driver.version>
         <mariadb.version>10.3.27</mariadb.version>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -59,7 +59,7 @@
         <org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <sun.saaj-impl.version>1.4.1.SP1</sun.saaj-impl.version>
         <org.jvnet.staxex.version>1.8.3</org.jvnet.staxex.version>
-	<io.agroal.version>1.17</io.agroal.version>
+	<io.agroal.version>2.1</io.agroal.version>
 
         <!--
             Quarkiverse dependency versions

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -59,7 +59,7 @@
         <org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <sun.saaj-impl.version>1.4.1.SP1</sun.saaj-impl.version>
         <org.jvnet.staxex.version>1.8.3</org.jvnet.staxex.version>
-	<io.agroal.version>1.17</io.agroal.version>
+	<io.agroal.version>1.15</io.agroal.version>
 
         <!--
             Quarkiverse dependency versions

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -59,6 +59,7 @@
         <org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <sun.saaj-impl.version>1.4.1.SP1</sun.saaj-impl.version>
         <org.jvnet.staxex.version>1.8.3</org.jvnet.staxex.version>
+	<io.agroal.version>1.17</io.agroal.version>
 
         <!--
             Quarkiverse dependency versions
@@ -105,6 +106,21 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-client-hotrod</artifactId>
                 <version>${infinispan.version}</version>
+            </dependency>
+	    <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-api</artifactId>
+                <version>${io.agroal.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-narayana</artifactId>
+                <version>${io.agroal.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-pool</artifactId>
+                <version>${io.agroal.version}</version>
             </dependency>
 
             <!-- Dependencies removed from JDK 11 and in compliance with those used by Wildfly. -->

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -59,7 +59,7 @@
         <org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <sun.saaj-impl.version>1.4.1.SP1</sun.saaj-impl.version>
         <org.jvnet.staxex.version>1.8.3</org.jvnet.staxex.version>
-	<io.agroal.version>2.1</io.agroal.version>
+	<io.agroal.version>1.17</io.agroal.version>
 
         <!--
             Quarkiverse dependency versions

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -59,7 +59,12 @@
         <org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <sun.saaj-impl.version>1.4.1.SP1</sun.saaj-impl.version>
         <org.jvnet.staxex.version>1.8.3</org.jvnet.staxex.version>
-	<io.agroal.version>1.15</io.agroal.version>
+
+        <!--
+            Use Agroal version 1.5 to resolve failure with acquisition timeout while waiting for new connection, as per
+            the comment https://github.com/keycloak/keycloak/issues/16448#issuecomment-1504734541
+        -->
+        <io.agroal.version>1.15</io.agroal.version>
 
         <!--
             Quarkiverse dependency versions
@@ -107,7 +112,7 @@
                 <artifactId>infinispan-client-hotrod</artifactId>
                 <version>${infinispan.version}</version>
             </dependency>
-	    <dependency>
+	        <dependency>
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-api</artifactId>
                 <version>${io.agroal.version}</version>


### PR DESCRIPTION
This PR downgrades the Agroal to v1.15 (from v1.16) to resolve  failure with acquisition timeout while waiting for new connection, as per the comment https://github.com/keycloak/keycloak/issues/16448#issuecomment-1504734541
