### PR TITLE
VZ-10275: Update Netty v.1.94.Final and H2 v2.2.220

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <cxf.jaxrs.version>3.3.10</cxf.jaxrs.version>
         <cxf.undertow.version>3.3.10</cxf.undertow.version>
         <dom4j.version>2.1.3</dom4j.version>
-        <h2.version>2.1.214</h2.version>
+        <h2.version>2.2.220</h2.version>
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
         <hibernate.core.version>5.6.10.Final</hibernate.core.version>
         <hibernate.c3p0.version>5.6.10.Final</hibernate.c3p0.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <picketbox.version>5.0.3.Final</picketbox.version>
         <google.guava.version>30.1-jre</google.guava.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <netty.version>4.1.86.Final</netty.version>
+        <netty.version>4.1.94.Final</netty.version>
 
         <!-- Openshift -->
         <version.com.openshift.openshift-restclient-java>9.0.5.Final</version.com.openshift.openshift-restclient-java>


### PR DESCRIPTION
Updates Netty to v.1.94.Final and H2 to v2.2.220 in Keycloak 20.0.1
