### PR TITLE
VZ-11493: Use distroless Java 17 base image

### DIFF
--- a/quarkus/container/Dockerfile_verrazzano
+++ b/quarkus/container/Dockerfile_verrazzano
@@ -27,22 +27,13 @@ RUN chmod -R g+rwX /opt/keycloak
 RUN (mkdir /opt/xa && \
     chmod -R g+rwX /opt/xa)
 
-FROM ghcr.io/oracle/oraclelinux:8-slim
+FROM ghcr.io/verrazzano/ol8-java21:v0.0.1-20231102152128-e7afc807
 ENV LANG en_US.UTF-8
 
 COPY --from=build_env --chown=1000:0 /opt/keycloak /opt/keycloak
 COPY --from=build_env --chown=1000:0 /opt/xa /opt/xa
 
-RUN microdnf update -y && \
-    microdnf install -y --nodocs java-11-openjdk-headless glibc-langpack-en && \
-    microdnf install -y python38 python38-pip && \
-    # remove the previously installed setuptools info
-    rm -rf /usr/lib/python3.8/site-packages/setuptools-41.6.0.dist-info && \
-    # install the upgraded setuptools
-    pip3 install setuptools --upgrade && \
-    rm -rf /usr/lib/python3.6 && \
-    microdnf clean all && rm -rf /var/cache/yum/* && \
-    echo "keycloak:x:0:root" >> /etc/group && \
+RUN echo "keycloak:x:0:root" >> /etc/group && \
     echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
 
 # Narayana JTA creates ObjectStore under the directory derived from system property user.dir, so make /opt/xa as working directory

--- a/quarkus/container/Dockerfile_verrazzano
+++ b/quarkus/container/Dockerfile_verrazzano
@@ -27,7 +27,7 @@ RUN chmod -R g+rwX /opt/keycloak
 RUN (mkdir /opt/xa && \
     chmod -R g+rwX /opt/xa)
 
-FROM ghcr.io/verrazzano/ol8-java17-jenkins:v0.0.1-20231102152128-e7afc807
+FROM ghcr.io/verrazzano/ol8-java17-jenkins:v0.0.1-20231108171318-97ee797f
 ENV LANG en_US.UTF-8
 
 COPY --from=build_env --chown=1000:0 /opt/keycloak /opt/keycloak

--- a/quarkus/container/Dockerfile_verrazzano
+++ b/quarkus/container/Dockerfile_verrazzano
@@ -27,7 +27,7 @@ RUN chmod -R g+rwX /opt/keycloak
 RUN (mkdir /opt/xa && \
     chmod -R g+rwX /opt/xa)
 
-FROM ghcr.io/verrazzano/ol8-java21:v0.0.1-20231102152128-e7afc807
+FROM ghcr.io/verrazzano/ol8-java17-jenkins:v0.0.1-20231102152128-e7afc807
 ENV LANG en_US.UTF-8
 
 COPY --from=build_env --chown=1000:0 /opt/keycloak /opt/keycloak

--- a/quarkus/container/Dockerfile_verrazzano
+++ b/quarkus/container/Dockerfile_verrazzano
@@ -27,7 +27,7 @@ RUN chmod -R g+rwX /opt/keycloak
 RUN (mkdir /opt/xa && \
     chmod -R g+rwX /opt/xa)
 
-FROM ghcr.io/verrazzano/ol8-java17-jenkins:v0.0.1-20231108171318-97ee797f
+FROM ghcr.io/verrazzano/ol8-java17:v0.0.1-20231127201043-98de115c
 ENV LANG en_US.UTF-8
 
 COPY --from=build_env --chown=1000:0 /opt/keycloak /opt/keycloak


### PR DESCRIPTION
Use distroless Java 17 base image as the final image. I also removed installation of python-related packages since I couldn't find any python code in the repo, and the acceptance tests all seem to pass without python being installed.

I also manually tested the UI and it all seems to work as expected.